### PR TITLE
Drop test for tracing and inline coroutine creation

### DIFF
--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -4641,7 +4641,7 @@ check_eval_breaker:
             if (Py_TYPE(function) == &PyFunction_Type) {
                 PyCodeObject *code = (PyCodeObject*)PyFunction_GET_CODE(function);
                 int is_coro = code->co_flags & (CO_GENERATOR | CO_COROUTINE | CO_ASYNC_GENERATOR);
-                inline_call = (is_coro || cframe.use_tracing) ? 0 : 1;
+                inline_call = !is_coro;
             }
 
             if (!inline_call) {
@@ -4656,7 +4656,6 @@ check_eval_breaker:
                 DISPATCH();
             }
 
-            assert(!cframe.use_tracing);
             InterpreterFrame *new_frame = _PyEval_FrameFromPyFunctionAndArgs(tstate, stack_pointer-oparg, oparg, function);
             if (new_frame == NULL) {
                 // When we exit here, we own all variables in the stack (the frame creation has not stolen


### PR DESCRIPTION
I've not attempted cleanup of the reference counting yet due to existing leaks.
These two commits are clean up before doing that.

The `simple_cframe` branch leaks references.
Do you need to merge in main to get https://github.com/python/cpython/pull/28493?

My plan is:
1. `make_coro` steal its argument's references.
2. All callers to anything that can steal refs passes 1 to steal args
3. Remove `steal` parameter
4. Push error cleanup downward, so callers never have to clean up.