### PR TITLE
test_cmd_line_scripts: Modify test_syntaxerror_multi_line_fstring

### DIFF
--- a/Lib/test/test_cmd_line_script.py
+++ b/Lib/test/test_cmd_line_script.py
@@ -636,9 +636,9 @@ class CmdLineTest(unittest.TestCase):
             self.assertEqual(
                 stderr.splitlines()[-3:],
                 [
-                    b'    foo"""',
-                    b'          ^',
-                    b'SyntaxError: f-string: empty expression not allowed',
+                    b'    foo = f"""{}',
+                    b'               ^',
+                    b'SyntaxError: invalid syntax',
                 ],
             )
 

--- a/Lib/test/test_cmd_line_script.py
+++ b/Lib/test/test_cmd_line_script.py
@@ -638,7 +638,7 @@ class CmdLineTest(unittest.TestCase):
                 [
                     b'    foo = f"""{}',
                     b'               ^',
-                    b'SyntaxError: invalid syntax',
+                    b'SyntaxError: f-string: empty expression not allowed',
                 ],
             )
 


### PR DESCRIPTION
Just want to say, new traceback more prettiest.
Altough, `SyntaxError: f-string: empty expression not allowed` looks more understandable than `SyntaxError: invalid syntax`.