### PR TITLE
fix(fstring): Expressions nested too deeply error

### DIFF
--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -511,6 +511,11 @@ x = (
                             ])
         self.assertRaises(SyntaxError, eval, "f'{" + "("*500 + "}'")
 
+    def test_fstring_nested_too_deeply(self):
+        self.assertAllRaise(SyntaxError,
+                            "f-string: expressions nested too deeply",
+                            ['f"{1+2:{1+2:{1+1:{1}}}}"'])
+
     def test_double_braces(self):
         self.assertEqual(f'{{', '{')
         self.assertEqual(f'a{{', 'a{')
@@ -741,6 +746,7 @@ x = (
         self.assertAllRaise(SyntaxError, 'unterminated string literal',
                             ["f'{\n}'",
                              ])
+
     def test_newlines_before_syntax_error(self):
         self.assertAllRaise(SyntaxError, "invalid syntax",
                 ["f'{.}'", "\nf'{.}'", "\n\nf'{.}'"])
@@ -1378,7 +1384,6 @@ x = (
         # the tabs to spaces just to shut up patchcheck.
         #self.assertEqual(f'X{x =}Y', 'Xx\t='+repr(x)+'Y')
         #self.assertEqual(f'X{x =       }Y', 'Xx\t=\t'+repr(x)+'Y')
-
 
     def test_walrus(self):
         x = 20

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -2427,6 +2427,9 @@ tok_get_fstring_mode(struct tok_state *tok, tokenizer_mode* current_tok, struct 
 {
     const char *p_start = NULL;
     const char *p_end = NULL;
+    int end_quote_size = 0;
+    int unicode_escape = 0;
+
     tok->start = tok->cur;
     tok->first_lineno = tok->lineno;
     tok->starting_col_offset = tok->col_offset;
@@ -2467,9 +2470,8 @@ tok_get_fstring_mode(struct tok_state *tok, tokenizer_mode* current_tok, struct 
     tok->tok_mode_stack_index--;
     return MAKE_TOKEN(FSTRING_END);
 
-  f_string_middle:
-    int end_quote_size = 0;
-    int unicode_escape = 0;
+f_string_middle:
+
     while (end_quote_size != current_tok->f_string_quote_size) {
         int c = tok_nextc(tok);
         if (c == EOF || (current_tok->f_string_quote_size == 1 && c == '\n')) {

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -2443,6 +2443,10 @@ tok_get_fstring_mode(struct tok_state *tok, tokenizer_mode* current_tok, struct 
 
     if ((start_char == '{' && peek1 != '{') || (start_char == '}' && peek1 != '}')) {
         if (start_char == '{') {
+            if (current_tok->bracket_mark_index >= MAX_EXPR_NEXTING) {
+                return MAKE_TOKEN(syntaxerror(tok, "f-string: expressions nested too deeply"));
+            }
+
             current_tok->bracket_mark[++current_tok->bracket_mark_index] = current_tok->bracket_stack;
         }
         tok->tok_mode_stack[tok->tok_mode_stack_index].kind = TOK_REGULAR_MODE;


### PR DESCRIPTION
In python 3.11:
```python
>>> f"{1+2:{1+2:{1+1:{1}}}}"
  File "<stdin>", line 1
    f"{1+2:{1+2:{1+1:{1}}}}"
                            ^
SyntaxError: f-string: expressions nested too deeply
```

In the dev version we have:
```python
>>> f"{1+2:{1+2:{1+1:{1}}}}"
  File "<stdin>", line 1
    f"{1+2:{1+2:{1+1:{1}}}}"
    ^
SyntaxError: unterminated f-string literal (detected at line 1)
```

This PR fixes that.