### PR TITLE
Preserve double open-braces in format specs

### DIFF
--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -2523,9 +2523,10 @@ f_string_middle:
             end_quote_size = 0;
         }
 
+        int in_format_spec = current_tok->last_expr_end != -1 && current_tok->bracket_mark_index >= 0;
         if (c == '{') {
             char peek = tok_nextc(tok);
-            if (peek != '{') {
+            if (peek != '{' || in_format_spec) {
                 tok_backup(tok, peek);
                 tok_backup(tok, c);
                 current_tok->bracket_mark[++current_tok->bracket_mark_index] = current_tok->bracket_stack;
@@ -2549,7 +2550,6 @@ f_string_middle:
             // scanning (indicated by the end of the expression being set) and we are not at the top level
             // of the bracket stack (-1 is the top level). Since format specifiers can't legally use double
             // brackets, we can bypass it here.
-            int in_format_spec = current_tok->last_expr_end != -1 && current_tok->bracket_mark_index >= 0;
             if (peek == '}' && !in_format_spec) {
                 p_start = tok->start;
                 p_end = tok->cur - 1;


### PR DESCRIPTION
This brings down the `test_fstring` failures to 7.

Python 3.10
```python
Python 3.10.9 (main, Mar  1 2023, 12:33:47) [Clang 14.0.6 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> f'{3:{{>10}}}'
  File "<stdin>", line 1
    ({>10})
      ^
SyntaxError: f-string: invalid syntax
```

Before this PR
```python
Python 3.12.0a6+ (heads/fstring-grammar-rebased-after-sprint:77fb2938a4, Apr  6 2023, 17:06:30) [Clang 14.0.3 (clang-1403.0.22.14.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> f'{3:{{>10}}}'
'{{{{{{{{{3}'
```

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
