### PR TITLE
Fix threading in calling PyOS_InputHook from new REPL

### DIFF
--- a/Include/pythonrun.h
+++ b/Include/pythonrun.h
@@ -17,9 +17,9 @@ PyAPI_FUNC(void) PyErr_Display(PyObject *, PyObject *, PyObject *);
 PyAPI_FUNC(void) PyErr_DisplayException(PyObject *);
 #endif
 
-
 /* Stuff with no proper home (yet) */
 PyAPI_DATA(int) (*PyOS_InputHook)(void);
+PyAPI_FUNC(int) _PyOS_CallInputHook(void);
 
 /* Stack size, in "pointers" (so we get extra safety margins
    on 64-bit platforms).  On a 32-bit platform, this translates

--- a/Lib/_pyrepl/reader.py
+++ b/Lib/_pyrepl/reader.py
@@ -645,7 +645,7 @@ class Reader:
             self.dirty = True
 
         while True:
-            self.call_PyOS_InputHook()
+            ctypes.pythonapi._PyOS_CallInputHook()
             event = self.console.get_event(block)
             if not event:  # can only happen if we're not blocking
                 return False
@@ -704,10 +704,3 @@ class Reader:
     def get_unicode(self) -> str:
         """Return the current buffer as a unicode string."""
         return "".join(self.buffer)
-
-    def call_PyOS_InputHook(self):
-        if self.input_hook_addr is None:
-            self.input_hook_addr = ctypes.c_void_p.in_dll(ctypes.pythonapi, 'PyOS_InputHook').value
-        if not self.input_hook_addr:
-            return
-        ctypes.PYFUNCTYPE(ctypes.c_int)(self.input_hook_addr)()

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -3329,3 +3329,15 @@ PyOS_setsig(int sig, PyOS_sighandler_t handler)
     return oldhandler;
 #endif
 }
+
+int _PyOS_CallInputHook(void)
+{
+    // The return value is ignored, but let's handle it anyway
+    int result = 0;
+    if (PyOS_InputHook) {
+        Py_BEGIN_ALLOW_THREADS;
+        result = PyOS_InputHook();
+        Py_END_ALLOW_THREADS;
+    }
+    return result;
+}


### PR DESCRIPTION
Just a proof-of-concept for what seems to make this work.

Since the PyOS_InputHook implementation in Tkinter sets the thread state, we need to allow threads around calling it.  I'm not sure that's possible directly from Python (maybe it is), so I just added a C function to handle this.  This seems to make things work correctly, at least for matplotlib and the [Tkinter reproducer here](https://github.com/python/cpython/issues/119842#issuecomment-2142717590).

I'm not sure the new function is in the right file.