### PR TITLE
fix: Show independent tasks in the table

### DIFF
--- a/Lib/asyncio/tools.py
+++ b/Lib/asyncio/tools.py
@@ -144,6 +144,17 @@ def build_task_table(result):
     table = []
     for tid, tasks in result:
         for task_id, task_name, awaited in tasks:
+            if not awaited:
+                table.append(
+                    [
+                        tid,
+                        hex(task_id),
+                        task_name,
+                        "",
+                        "",
+                        "0x0"
+                    ]
+                )
             for stack, awaiter_id in awaited:
                 coroutine_chain = " -> ".join(stack)
                 awaiter_name = id2name.get(awaiter_id, "Unknown")

--- a/Lib/test/test_asyncio/test_tools.py
+++ b/Lib/test/test_asyncio/test_tools.py
@@ -164,6 +164,37 @@ TEST_INPUTS_TREE = [
             ]
         ),
     ],
+    [
+        # test case containing two roots, one of them without subtasks
+        (
+            [
+                (1, [(2, "Task-5", [])]),
+                (
+                    3,
+                    [
+                        (4, "Task-1", []),
+                        (5, "Task-2", [[["main"], 4]]),
+                        (6, "Task-3", [[["main"], 4]]),
+                        (7, "Task-4", [[["main"], 4]]),
+                    ],
+                ),
+                (8, []),
+                (0, []),
+            ]
+        ),
+        (
+            [
+                ["└── (T) Task-5"],
+                [
+                    "└── (T) Task-1",
+                    "    └──  main",
+                    "        ├── (T) Task-2",
+                    "        ├── (T) Task-3",
+                    "        └── (T) Task-4",
+                ],
+            ]
+        ),
+    ],
 ]
 
 TEST_INPUTS_CYCLES_TREE = [
@@ -300,6 +331,7 @@ TEST_INPUTS_TABLE = [
         ),
         (
             [
+                [1, "0x2", "Task-1", "", "", "0x0"],
                 [
                     1,
                     "0x3",
@@ -409,12 +441,42 @@ TEST_INPUTS_TABLE = [
         ),
         (
             [
+                [9, "0x5", "Task-5", "", "", "0x0"],
                 [9, "0x6", "Task-6", "main2", "Task-5", "0x5"],
                 [9, "0x7", "Task-7", "main2", "Task-5", "0x5"],
                 [9, "0x8", "Task-8", "main2", "Task-5", "0x5"],
+                [10, "0x1", "Task-1", "", "", "0x0"],
                 [10, "0x2", "Task-2", "main", "Task-1", "0x1"],
                 [10, "0x3", "Task-3", "main", "Task-1", "0x1"],
                 [10, "0x4", "Task-4", "main", "Task-1", "0x1"],
+            ]
+        ),
+    ],
+    [
+        # test case containing two roots, one of them without subtasks
+        (
+            [
+                (1, [(2, "Task-5", [])]),
+                (
+                    3,
+                    [
+                        (4, "Task-1", []),
+                        (5, "Task-2", [[["main"], 4]]),
+                        (6, "Task-3", [[["main"], 4]]),
+                        (7, "Task-4", [[["main"], 4]]),
+                    ],
+                ),
+                (8, []),
+                (0, []),
+            ]
+        ),
+        (
+            [
+                [1, "0x2", "Task-5", "", "", "0x0"],
+                [3, "0x4", "Task-1", "", "", "0x0"],
+                [3, "0x5", "Task-2", "main", "Task-1", "0x4"],
+                [3, "0x6", "Task-3", "main", "Task-1", "0x4"],
+                [3, "0x7", "Task-4", "main", "Task-1", "0x4"],
             ]
         ),
     ],
@@ -440,6 +502,7 @@ TEST_INPUTS_TABLE = [
         ),
         (
             [
+                [1, "0x2", "Task-1", "", "", "0x0"],
                 [1, "0x3", "a", "awaiter2", "b", "0x4"],
                 [1, "0x3", "a", "main", "Task-1", "0x2"],
                 [1, "0x4", "b", "awaiter", "a", "0x3"],
@@ -480,6 +543,7 @@ TEST_INPUTS_TABLE = [
         ),
         (
             [
+                [1, "0x2", "Task-1", "", "", "0x0"],
                 [
                     1,
                     "0x3",
@@ -570,7 +634,10 @@ class TestAsyncioToolsBasic(unittest.TestCase):
 
     def test_only_independent_tasks_table(self):
         input_ = [(1, [(10, "taskA", []), (11, "taskB", [])])]
-        self.assertEqual(tools.build_task_table(input_), [])
+        self.assertEqual(
+            tools.build_task_table(input_),
+            [[1, "0xa", "taskA", "", "", "0x0"], [1, "0xb", "taskB", "", "", "0x0"]],
+        )
 
     def test_single_task_tree(self):
         """Test print_async_tree with a single task and no awaits."""
@@ -599,7 +666,7 @@ class TestAsyncioToolsBasic(unittest.TestCase):
                 ],
             )
         ]
-        expected_output = []
+        expected_output = [[1, "0x2", "Task-1", "", "", "0x0"]]
         self.assertEqual(tools.build_task_table(result), expected_output)
 
     def test_cycle_detection(self):
@@ -653,6 +720,7 @@ class TestAsyncioToolsBasic(unittest.TestCase):
             )
         ]
         expected_output = [
+            [1, "0x2", "Task-1", "", "", "0x0"],
             [1, "0x3", "Task-2", "main", "Task-1", "0x2"],
             [1, "0x4", "Task-3", "main", "Task-2", "0x3"],
         ]


### PR DESCRIPTION
Having a script with two independent event loops, only one of them is displayed in the table. This PR fixes that.

```python
import asyncio
import threading

async def factorial(name, number):
    f = 1
    for i in range(2, number + 1):
        print(f"Task {name}: Compute factorial({number}), currently i={i}...")
        await asyncio.sleep(1)
        f *= i
    print(f"Task {name}: factorial({number}) = {f}")
    return f

async def main():
    # Schedule three calls *concurrently*:
    L = await asyncio.gather(
        factorial("A", 200),
        factorial("B", 300),
        factorial("C", 400),
    )
    print(L)

async def main2():
    await asyncio.sleep(100)


t1 = threading.Thread(target=asyncio.run, args=(main(),))
t2 = threading.Thread(target=asyncio.run, args=(main2(),))

t1.start()
t2.start()
t1.join()
t2.join()
```


