### PR TITLE
More Tachyon Opcode CSS Fixes: Responsive Heatmap Edition

### DIFF
--- a/Lib/profiling/sampling/_heatmap_assets/heatmap.css
+++ b/Lib/profiling/sampling/_heatmap_assets/heatmap.css
@@ -691,6 +691,15 @@
   flex-shrink: 0;
 }
 
+/* Legend Controls Group - wraps toggles and bytecode button together */
+.legend-controls {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  flex-shrink: 0;
+  margin-left: auto;
+}
+
 /* Toggle Switch Styles */
 .toggle-switch {
   display: inline-flex;
@@ -724,11 +733,6 @@
   opacity: 0.4;
   pointer-events: none;
   cursor: not-allowed;
-}
-
-/* Push toggles to the right */
-#toggle-color-mode {
-  margin-left: auto;
 }
 
 .toggle-track {
@@ -1147,6 +1151,15 @@
   .stats-summary {
     grid-template-columns: repeat(2, 1fr);
   }
+
+  .legend-content {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .legend-controls {
+    margin-left: 0;
+  }
 }
 
 @media (max-width: 900px) {
@@ -1166,12 +1179,64 @@
 
   .legend-content {
     flex-direction: column;
+    align-items: center;
     gap: 12px;
   }
 
   .legend-gradient {
     width: 100%;
     max-width: none;
+  }
+
+  .legend-separator {
+    width: 80%;
+    height: 1px;
+  }
+
+  .legend-controls {
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .legend-controls .toggle-switch {
+    justify-content: center;
+  }
+
+  .legend-controls .toggle-switch .toggle-label:first-child {
+    width: 70px;
+    text-align: right;
+  }
+
+  .legend-controls .toggle-switch .toggle-label:last-child {
+    width: 90px;
+    text-align: left;
+  }
+
+  /* Compact code columns on small screens */
+  .header-line-number,
+  .line-number {
+    width: 40px;
+  }
+
+  .header-samples-self,
+  .header-samples-cumulative,
+  .line-samples-self,
+  .line-samples-cumulative {
+    width: 55px;
+    font-size: 10px;
+  }
+
+  /* Adjust padding - headers need vertical, data rows don't */
+  .header-line-number,
+  .header-samples-self,
+  .header-samples-cumulative {
+    padding: 8px 4px;
+  }
+
+  .line-number,
+  .line-samples-self,
+  .line-samples-cumulative {
+    padding: 0 4px;
   }
 }
 

--- a/Lib/profiling/sampling/_heatmap_assets/heatmap_pyfile_template.html
+++ b/Lib/profiling/sampling/_heatmap_assets/heatmap_pyfile_template.html
@@ -69,25 +69,27 @@
                     <span>Hot</span>
                 </div>
                 <div class="legend-separator" aria-hidden="true"></div>
-                <div class="toggle-switch" id="toggle-color-mode" title="Toggle between self time and total time coloring">
-                    <span class="toggle-label active">Self Time</span>
-                    <div class="toggle-track"></div>
-                    <span class="toggle-label">Total Time</span>
+                <div class="legend-controls">
+                    <div class="toggle-switch" id="toggle-color-mode" title="Toggle between self time and total time coloring">
+                        <span class="toggle-label active">Self Time</span>
+                        <div class="toggle-track"></div>
+                        <span class="toggle-label">Total Time</span>
+                    </div>
+                    <div class="toggle-switch" id="toggle-cold" title="Toggle visibility of lines with zero samples">
+                        <span class="toggle-label active">Show All</span>
+                        <div class="toggle-track"></div>
+                        <span class="toggle-label">Hot Only</span>
+                    </div>
+                    <div class="toggle-switch" id="toggle-spec-view" title="Color lines by specialization level (requires bytecode data)">
+                        <span class="toggle-label active">Heat</span>
+                        <div class="toggle-track"></div>
+                        <span class="toggle-label">Specialization</span>
+                    </div>
+                    <div class="legend-separator" aria-hidden="true"></div>
+                    <button class="bytecode-expand-all" id="toggle-all-bytecode" title="Expand/collapse all bytecode panels (keyboard: b)">
+                        <span class="expand-icon" aria-hidden="true">▶</span> Bytecode
+                    </button>
                 </div>
-                <div class="toggle-switch" id="toggle-cold" title="Toggle visibility of lines with zero samples">
-                    <span class="toggle-label active">Show All</span>
-                    <div class="toggle-track"></div>
-                    <span class="toggle-label">Hot Only</span>
-                </div>
-                <div class="toggle-switch" id="toggle-spec-view" title="Color lines by specialization level (requires bytecode data)">
-                    <span class="toggle-label active">Heat</span>
-                    <div class="toggle-track"></div>
-                    <span class="toggle-label">Specialization</span>
-                </div>
-                <div class="legend-separator" aria-hidden="true"></div>
-                <button class="bytecode-expand-all" id="toggle-all-bytecode" title="Expand/collapse all bytecode panels (keyboard: b)">
-                    <span class="expand-icon" aria-hidden="true">▶</span> Bytecode
-                </button>
             </div>
         </div>
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
Responsive fixes for ya for https://github.com/python/cpython/pull/142394!

**Before:**
Toggles overflowed on x-axis in mid-range screens and were misaligned on small screens. Column padding was too much on small screens

 _Small screen_
<img width="990" height="1786" alt="image" src="https://github.com/user-attachments/assets/e2e4933a-ec35-42e7-af27-c17fed3f9b7a" />

_Mid-size screen_
<img width="1844" height="1862" alt="image" src="https://github.com/user-attachments/assets/5d9170c5-aa96-46da-a3d7-aede11ab623e" />


Column padding was too much on small screens
The toggle section now moves and wraps as a group, making things flow better. Padding was adjusted to be easier to read on small screens

 _Small screen_
<img width="960" height="1726" alt="image" src="https://github.com/user-attachments/assets/db4525e8-4aa1-4172-85a3-5e3ceeaf1125" />

_Mid-size screen_
<img width="2036" height="1832" alt="image" src="https://github.com/user-attachments/assets/63d780c1-a837-4fdb-8b13-d683f1769a62" />

Was going to just open this against main but the addition of the new toggle stresses existing styles so figured I'd fix this way
