### PR TITLE
Fix history mode exiting on Windows

### DIFF
--- a/Lib/_pyrepl/commands.py
+++ b/Lib/_pyrepl/commands.py
@@ -485,16 +485,17 @@ class show_history(Command):
         from .pager import get_pager
         from site import gethistoryfile
 
+        # After the pager exits, the screen state is unknown (Unix may
+        # restore via alternate screen, Windows shows pager output).
+        # Clear and force a full redraw at the end for consistency.
+        self.reader.console.clear()
+
         history = os.linesep.join(self.reader.history[:])
         self.reader.console.restore()
         pager = get_pager()
         pager(history, gethistoryfile())
         self.reader.console.prepare()
 
-        # After the pager exits, the screen state is unknown (Unix may
-        # restore via alternate screen, Windows shows pager output).
-        # Clear and force a full redraw for consistency.
-        self.reader.console.clear()
         self.reader.invalidate_full()
 
 

--- a/Lib/_pyrepl/unix_console.py
+++ b/Lib/_pyrepl/unix_console.py
@@ -155,7 +155,7 @@ class UnixRefreshPlan:
 
     After the user types ``e`` to complete ``name``::
 
-        Before: >>> def greet(nam|):   
+        Before: >>> def greet(nam|):
                                  ▲
                         LineUpdate here: insert_char "e"
 


### PR DESCRIPTION
The only time when less isn't more... or is it?

Environment | Demo
-- | --
Windows PowerShell `more` | <video src="https://github.com/user-attachments/assets/81651b36-418d-4a2c-96ae-c2171ce9c487"></video>
Windows PowerShell `less` | <video src="https://github.com/user-attachments/assets/b1284efd-ec92-4c5e-913e-0339bb70e6c3"></video>
Windows CMD `more` | <video src="https://github.com/user-attachments/assets/393e2d80-1119-49b6-83dc-88bc0ab75d9f"></video>
Windows MSYS2 bash `more` | <video src="https://github.com/user-attachments/assets/0ef29d14-3fa0-481d-bc29-a3f69cf4759b"></video>
Windows MSYS2 bash `less` | <video src="https://github.com/user-attachments/assets/2d082939-4b3e-4844-8626-2798b98d2364"></video>
macOS bash `more` (`more` is `less` but argv0 alters behavior) | <video src="https://github.com/user-attachments/assets/bba37d27-3b08-4bd2-8168-ec7c5d3f8149"></video>
macOS bash `less` | <video src="https://github.com/user-attachments/assets/e88d746a-bcc6-4b3a-a84a-066fc4faa83e"></video>